### PR TITLE
Added fan speed of auto & JSON return URL in logger

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -215,7 +215,10 @@ async def lge_devices_setup(hass, client, config_entry):
         try:
             for device in client.devices:
                 hass.data[KEY_SMARTTHINQ_DEVICES].append(device.id)
-
+                _LOGGER.info("Found LGE Device with Name: {} - Type: {} - InfoUrl: {}".format(
+                                device.name,
+                                device.type.name,
+                                device.model_info_url))
             for component in SMARTTHINQ_COMPONENTS:
                 discovery.load_platform(hass, component, DOMAIN, {}, config_entry)
                 device_count += 1

--- a/climate.py
+++ b/climate.py
@@ -40,6 +40,7 @@ FAN_MODES = {
     "HIGH": c_const.FAN_HIGH,
     "NATURE": "nature",
     "POWER": "power",
+    "AUTO": "auto",
 }
 
 


### PR DESCRIPTION
Hi @marciogranzotto - I've added this in here (as it was another requirement to get my system working). 

I'm not sure if there is a way we could poll the capabilities of a machine, and return those, to allow the integration to only see modes available to each system? 